### PR TITLE
FakeGPS now allows assigning of start and stop location in configuration

### DIFF
--- a/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsConfig.java
+++ b/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsConfig.java
@@ -22,11 +22,25 @@ public class FakeGpsConfig extends SensorConfig
     
     public String googleApiUrl = "http://maps.googleapis.com/maps/api/directions/json";
     
+    public double vehicleSpeed = 40; // km/h
+
+    // Use these to add specific start and stop locations
+    
+    public double startLatitude = Double.NaN;  // in degrees
+    
+    public double stopLatitude;  // in degrees
+
+    public double startLongitude;  // in degrees
+
+    public double stopLongitude;  // in degrees
+
+    
+    // Use these if you want random start and stop locations
+    
     public double centerLatitude; // in deg
     
     public double centerLongitude; // in deg
     
     public double areaSize = 0.1; // in deg
     
-    public double vehicleSpeed = 40; // km/h
 }

--- a/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsModuleDescriptor.java
+++ b/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsModuleDescriptor.java
@@ -32,7 +32,7 @@ public class FakeGpsModuleDescriptor implements IModuleProvider
     @Override
     public String getModuleDescription()
     {
-        return "Sensor outputing fake GPS sensor data generated from Google Directions results";
+        return "Sensor outputting simulated GPS sensor data generated from Google Directions results";
     }
 
 

--- a/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsOutput.java
+++ b/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsOutput.java
@@ -109,23 +109,42 @@ public class FakeGpsOutput extends AbstractSensorOutput<FakeGpsSensor>
     {
         FakeGpsConfig config = getParentModule().getConfiguration();
         
-        // generate random start/end coordinates
+        // get or randomly generate start/end coordinates
         double startLat;
         double startLong;
+        double endLat;
+        double endLong;
+        
+        // meb: added ability to specify start and stop location
         if (trajPoints.isEmpty())
         {
-            startLat = config.centerLatitude + (Math.random()-0.5) * config.areaSize;
-            startLong = config.centerLongitude + (Math.random()-0.5) * config.areaSize;
+        	
+        	if (Double.isNaN(config.startLatitude)){
+        		// if startLat not given, pick random start and stop within given area    		
+	            startLat = config.centerLatitude + (Math.random()-0.5) * config.areaSize;
+	            startLong = config.centerLongitude + (Math.random()-0.5) * config.areaSize;
+	            endLat = config.centerLatitude + (Math.random()-0.5) * config.areaSize;
+	            endLong = config.centerLongitude + (Math.random()-0.5) * config.areaSize;
+
+        	}
+        	else {
+	        	// use start location provided in configuration
+	            startLat = config.startLatitude;
+	        	startLong = config.startLongitude;
+	        	endLat = config.stopLatitude;
+	        	endLong = config.stopLongitude;
+        	}
         }
         else
         {
-            // restart from end of previous track
+            // restart from end of previous track and go to random end
             double[] lastPoint = trajPoints.get(trajPoints.size()-1);
             startLat = lastPoint[0];
             startLong = lastPoint[1];
-        }        
-        double endLat = config.centerLatitude + (Math.random()-0.5) * config.areaSize;
-        double endLong = config.centerLongitude + (Math.random()-0.5) * config.areaSize;
+            endLat = config.centerLatitude + (Math.random()-0.5) * config.areaSize;
+            endLong = config.centerLongitude + (Math.random()-0.5) * config.areaSize;
+        } 
+        
         
         try
         {

--- a/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsSensor.java
+++ b/sensorhub-driver-fakegps/src/main/java/org/sensorhub/impl/sensor/fakegps/FakeGpsSensor.java
@@ -21,7 +21,7 @@ import org.sensorhub.impl.sensor.AbstractSensorModule;
 
 /**
  * <p>
- * Driver implementation outputing simulated GPS data after
+ * Driver implementation outputting simulated GPS data after
  * requesting trajectories from Google Directions.
  * </p>
  *
@@ -49,7 +49,7 @@ public class FakeGpsSensor extends AbstractSensorModule<FakeGpsConfig>
             super.updateSensorDescription();
             sensorDescription.setId("GPS_SENSOR");
             sensorDescription.setUniqueIdentifier("urn:test:sensors:fakegps");
-            sensorDescription.setDescription("Fake GPS sensor generating data along random itineraries obtained using Google Direction API");
+            sensorDescription.setDescription("Simulated GPS sensor generating data along random itineraries obtained using Google Direction API");
         }
     }
 


### PR DESCRIPTION
Small set of changes to FakeGPS to support assigning start and stop location to route. After route is complete it then continues to a randomly selected destination.  If no start and stop location is provided, a random start and destination is selected.
